### PR TITLE
Add network.target to unit file

### DIFF
--- a/etc/initsystem/icinga2.service.cmake
+++ b/etc/initsystem/icinga2.service.cmake
@@ -1,6 +1,6 @@
 [Unit]
 Description=Icinga host/service/network monitoring system
-After=syslog.target postgresql.service mariadb.service carbon-cache.service
+After=syslog.target network.target postgresql.service mariadb.service carbon-cache.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Icinga2 fails with 'Cannot bind TCP socket for host', if other services requiring network.target are not installed.
